### PR TITLE
Fix new_fluid_file_stream_loader not returning anything

### DIFF
--- a/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -189,6 +189,8 @@ fluid_stream_loader_t* new_fluid_file_stream_loader()
   loader->read = fluid_file_stream_loader_read;
   loader->safe_read = fluid_file_stream_loader_safe_read;
   loader->get_modtime = fluid_get_file_modification_time;
+
+  return loader;
 }
 
 


### PR DESCRIPTION
This one missing line caused a crash when a soundfont was loaded from a file, rendering the library effectively useless.
